### PR TITLE
Home page text and styling update

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,26 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.notice {
+  padding: 15px;
+  background-color: #fcd6d3;
+  color: #333;
+  clear: both;
+  margin: 20px 0;
+}
+
+.map-responsive {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+  height: 0;
+}
+.map-responsive iframe {
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}

--- a/index.md
+++ b/index.md
@@ -4,24 +4,22 @@ layout: page
 
 <img src="assets/images/home.jpg" alt="St. Elisabeth Church in Hamburg" style="width: 200px; float: right; margin: 0 0 20px 20px;">
 
-Welcome to the website of the Hamburg English Speaking Community.
-This website is still under construction. But here's some information for you to get started off!
+## Welcome!
+We are a vibrant community of English-speaking Catholics from across the globe. Whether you are moving to Hamburg permanently, on a temporary assignment, or just passing through the city as a traveler, you are welcome to celebrate mass with us in English. To stay up to date on activities and opportunities, please subscribe to our monthly email newsletter.
 
-We are a vibrant community of English Speaking Catholics from across the Globe.
+## Mass Time and Location
+Mass is held in English at 12:00 noon every Sunday at St. Elisabeth Church at Oberstraße 67 in Hamburg.
 
-### Sunday Services
+<div class="map-responsive">
+  <iframe width="800" height="600" id="gmap_canvas" src="https://maps.google.com/maps?q=Kath.%20Kirchengemeinde%20St.%20Elisabeth%20Hamburg&t=&z=13&ie=UTF8&iwloc=&output=embed" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"></iframe>
+</div>
 
-Mass in English at 12:00 noon at St. Elisabeth's
-
-#### Current COVID Regulations
-In addition to the coronavirus guidelines issued by the Archdiocese, here are some details about how masses are run at St. Elisabeth:
-
-- We can only have 40 households in the church at a time. If we run out of space, we will unfortunately need to turn people away at the door. For the best chance of getting a seat, please arrive 10-15 minutes early.
-- All parishioners will be required to sign in at the entrance, disinfect their hands, and wear a mask during mass (except children below 7, who must remain with their parents). Ushers will seat you in a specific pew when you arrive.
-
-#### Location
-Kath. Kirchengemeinde St. Elisabeth Hamburg<br/>
-Oberstraße 67<br/>
-20149 Hamburg<br/>
-
-<div class="mapouter"><div class="gmap_canvas"><iframe width="800" height="400" id="gmap_canvas" src="https://maps.google.com/maps?q=Kath.%20Kirchengemeinde%20St.%20Elisabeth%20Hamburg&t=&z=13&ie=UTF8&iwloc=&output=embed" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"></iframe><a href="https://www.embedgooglemap.org">embed google map</a></div><style>.mapouter{position:relative;text-align:right;height:400px;width:800px;}.gmap_canvas {overflow:hidden;background:none!important;height:400px;width:800px;}</style></div>
+<div class="notice">
+  <h2>Current COVID-19 Regulations</h2>
+  <p>In addition to the <a href="https://www.erzbistum-hamburg.de/Themenbereich-Corona_Coronavirus-Erzbistum-Hamburg">coronavirus guidelines</a> issued by the Archdiocese, here are some details about how English language masses are run at St. Elisabeth until further notice:</p>
+  <ul>
+    <li>If you have any symptoms of illness, if you are in a high-risk group, or if you aren't able to sit for an hour with a mask fully covering your nose and mouth, please don't attend mass in person. There are many options for attending mass online.</li>
+    <li>All parishioners will be required to sign in at the entrance, disinfect their hands, and wear a mask during mass (except children below 7, who must remain with their parents). Ushers will seat you in a specific pew when you arrive.</li>
+    <li>We are limited to 40 households in the church at a time. If we run out of space, we will unfortunately need to turn people away at the door. We do not accept reservations for seats; for the best chance of getting a seat, please arrive 10-15 minutes early.</li>
+  </ul>
+</div>

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ We are a vibrant community of English-speaking Catholics from across the globe. 
 Mass is held in English at 12:00 noon every Sunday at St. Elisabeth Church at Oberstraße 67 in Hamburg.
 
 <div class="map-responsive">
-  <iframe width="800" height="600" id="gmap_canvas" src="https://maps.google.com/maps?q=Kath.%20Kirchengemeinde%20St.%20Elisabeth%20Hamburg&t=&z=13&ie=UTF8&iwloc=&output=embed" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"></iframe>
+  <iframe width="800" height="400" id="gmap_canvas" src="https://maps.google.com/maps?q=Kath.%20Kirchengemeinde%20St.%20Elisabeth%20Hamburg&t=&z=13&ie=UTF8&iwloc=&output=embed" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"></iframe>
 </div>
 
 <div class="notice">


### PR DESCRIPTION
Updated the text and order of the home page.

Added an SCSS file (as advised [here](https://lzone.de/blog/How-to-use-custom-CSS-with-Jekyll-Minima-theme)) to create a red background for the COVID notice, and to make the Google Map responsive (as explained [here](https://blog.duda.co/responsive-google-maps-for-your-website)).