### PR TITLE
Add "Newsletter" to main navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,9 @@ page_list:
   - page:
       name: Resources
       url: /resources
+  - page:
+      name: Newsletter
+      url: /newsletter
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
I wanted to add a "Newsletter" link back to the main navigation, so it's easier to find.

(I'd also love to know how many newsletter subscribers we have at this point, if you wouldn't mind checking...)