### PR TITLE
Update homepage banner with Ash Wednesday schedule

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,10 +4,14 @@ background: 'assets/images/header.jpg'
 ---
 
 <div class="alert alert-info mb-5">
-  <h3>Christmas Schedule</h3>  
+  <h3>Ash Wednesday Schedule</h3>
     <ul>
-      <li>Christmas Eve (24 Dec 2025) - No English mass</li>
-      <li>Christmas (25 Dec 2025) - English mass at 12:00 noon</li>      
+      <li>There will be no Ash Wednesday Mass in English.</li>
+      <li>Ashes will be distributed on Sunday, 22 March, after the Sunday Mass.</li>
+      <li>Those who wish to attend Ash Wednesday Mass may do so in German at one of the many parishes in Hamburg, including:</li>
+      <li>Mariendom - 12:00 noon and 18:15</li>
+      <li>Sankt Sophien - 18:00</li>
+      <li>Kleiner Michel - 19:00</li>
     </ul>
 </div>
 


### PR DESCRIPTION
### Motivation
- Replace the outdated Christmas schedule on the homepage with current Ash Wednesday information stating there is no English Mass, that ashes will be distributed after the Sunday Mass on 22 March, and listing German-language Mass options in Hamburg.

### Description
- Updated `index.md` alert block: changed the heading to "Ash Wednesday Schedule" and replaced the Christmas items with the supplied, polished details.
- Added German Ash Wednesday Mass times for `Mariendom` (12:00 and 18:15), `Sankt Sophien` (18:00), and `Kleiner Michel` (19:00).
- Saved and committed the change with the commit message `Update homepage notice to Ash Wednesday schedule`.

### Testing
- Verified the content change via `git diff -- index.md` and inspected `index.md` with `nl`, which show the new banner content (success).
- Ran `git add` and `git commit` which completed successfully (success).
- Attempted to run `bundle install` and `bundle exec jekyll serve` for a local preview, but `bundle install` failed due to a RubyGems `403 Forbidden` error so the site build could not be completed (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993458db088832cb192da5e509d4cb0)