### PR TITLE
Update homepage Holy Week announcement

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,15 +4,12 @@ background: 'assets/images/header.jpg'
 ---
 
 <div class="alert alert-info mb-5">
-  <h3>Ash Wednesday Schedule</h3>
-    <ul>
-      <li>There will be no Ash Wednesday Mass in English.</li>
-      <li>Ashes will be distributed on Sunday, 22 March, after the Sunday Mass.</li>
-      <li>Those who wish to attend Ash Wednesday Mass may do so in German at one of the many parishes in Hamburg, including:</li>
-      <li>Mariendom - 12:00 noon and 18:15</li>
-      <li>Sankt Sophien - 18:00</li>
-      <li>Kleiner Michel - 19:00</li>
-    </ul>
+  <h3>Holy Week Schedule</h3>
+  <ul>
+    <li>Maundy Thursday - There will be no English Service.</li>
+    <li>Good Friday Services at 5:30pm.</li>
+    <li>Easter Sunday Mass at 12 noon.</li>
+  </ul>
 </div>
 
 <div class="alert alert-info mb-5">


### PR DESCRIPTION
### Motivation
- Replace the outdated Ash Wednesday notice on the homepage with the requested Holy Week schedule to inform visitors of the upcoming service changes.

### Description
- Updated the announcement block in `index.md` to a "Holy Week Schedule" and added the three items: Maundy Thursday — no English service; Good Friday — services at 5:30pm; Easter Sunday Mass — 12 noon, and committed the change with message `Update homepage announcement for Holy Week schedule`.

### Testing
- Executed the update and verified changes with `nl -ba index.md | sed -n '1,70p'`, checked repository state with `git status --short`, and confirmed the commit with `git show --stat --oneline HEAD`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbab5d8afc832c8edb4618578cf8a4)