### PR TITLE
Remove First Holy Communion registration announcement from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,11 +12,6 @@ background: 'assets/images/header.jpg'
   </ul>
 </div>
 
-<div class="alert alert-info mb-5">
-	<h4> First Holy Communion and Confirmation Registration</h4>
-	<a href="https://forms.gle/SUL7Nw4VS8UxmFqEA">Form</a>
-</div>
-
 ## Welcome!
 <img src="assets/images/home.jpg" alt="St. Elisabeth Church in Hamburg" style="width: 200px; float: right; margin: 0 0 20px 20px;">
 


### PR DESCRIPTION
### Motivation
- Remove an outdated First Holy Communion and Confirmation registration announcement (and its Google Form link) from the homepage so the front page content is current.

### Description
- Deleted the alert block containing the "First Holy Communion and Confirmation Registration" header and the `https://forms.gle/...` link from `index.md`.

### Testing
- Verified the change by inspecting the updated file with `nl -ba index.md | sed -n '1,50p'` and checking repository status with `git status --short`, both indicating the content removal was applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb16dc7f4832c9bf111158e13225b)