### PR TITLE
Remove Holy Week / Easter Mass timings banner from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,15 +3,6 @@ layout: home
 background: 'assets/images/header.jpg'
 ---
 
-<div class="alert alert-info mb-5">
-  <h3>Holy Week Schedule</h3>
-  <ul>
-    <li>Maundy Thursday - There will be no English Service.</li>
-    <li>Good Friday Services at 5:30pm.</li>
-    <li>Easter Sunday Mass at 12 noon.</li>
-  </ul>
-</div>
-
 ## Welcome!
 <img src="assets/images/home.jpg" alt="St. Elisabeth Church in Hamburg" style="width: 200px; float: right; margin: 0 0 20px 20px;">
 


### PR DESCRIPTION
### Motivation
- Remove the temporary Holy Week/Easter Mass timings alert from the homepage so the site doesn't display outdated seasonal messaging.

### Description
- Deleted the alert block containing the Holy Week schedule from `index.md`, so the page now begins directly with the `Welcome!` section.

### Testing
- No automated tests were executed because this is a content-only Markdown change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62a15d1ac832c95a13366b38a65fc)